### PR TITLE
Fix ConstraintDual for vector set of length 1

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -201,7 +201,7 @@ function MOI.get(
     if(opt.sense != MOI.FEASIBILITY_SENSE)
         λ=abs.(opt.info.λ[rows]) # λ for lower bounds ≥ 0 in MOI
     else
-        λ = (length(rows)>1) ? zeros(Cdouble,length(rows)) : 0.0
+        λ = (S <: MOI.AbstractVectorSet) ? zeros(Cdouble,length(rows)) : 0.0
     end
     return λ
 end


### PR DESCRIPTION
With a vector set with only one row, you still need to return a vector of one element.