### PR TITLE
Update README.md for JuMP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
 # DAQP.jl
-[![CI](https://github.com/darnstrom/DAQP.jl/workflows/CI/badge.svg)](https://github.com/darnstrom/DAQP.jl/actions)
-[![Code coverage](http://codecov.io/gh/darnstrom/DAQP.jl/graphs/badge.svg)](http://codecov.io/github/darnstrom/DAQP.jl)
 
-Julia interface for the Quadratic Programming solver DAQP.
+[![](https://github.com/darnstrom/DAQP.jl/workflows/CI/badge.svg)](https://github.com/darnstrom/DAQP.jl/actions)
+[![](http://codecov.io/gh/darnstrom/DAQP.jl/graphs/badge.svg)](http://codecov.io/github/darnstrom/DAQP.jl)
 
-General information about the solver is provided [here](https://darnstrom.github.io/daqp/), and specifics for the Julia interface are given [here](https://darnstrom.github.io/daqp/start/julia). 
+[DAQP.jl](https://github.com/darnstrom/DAQP.jl) is a Julia wrapper for the
+Quadratic Programming solver [DAQP](https://github.com/darnstrom/daqp).
+
+## License
+
+DAQP.jl is licensed under the [MIT license](https://github.com/darnstrom/DAQP.jl/blob/main/LICENSE).
+
+The underlying solver, [darnstrom/daqp](https://github.com/darnstrom/daqp) is
+licensed under the [MIT license](https://github.com/darnstrom/daqp/blob/master/LICENSE).
+
+## Installation
+
+Install DAQP.jl usinng the Julia package manager:
+
+```julia
+import Pkg
+Pkg.add("DAQP")
+```
+
+## Use with JuMP
+
+To use DAQP with JuMP, do:
+```
+using JuMP, DAQP
+model = Model(DAQP.Optimizer)
+```
+
+## Documentation
+
+General information about the solver is available at [https://darnstrom.github.io/daqp/](https://darnstrom.github.io/daqp/),
+and specifics for the Julia interface are available at
+[https://darnstrom.github.io/daqp/start/julia](https://darnstrom.github.io/daqp/start/julia). 


### PR DESCRIPTION
I'm adding DAQP to the JuMP documentation: https://github.com/jump-dev/JuMP.jl/pull/3365

Here's what it currently looks like: https://jump.dev/JuMP.jl/previews/PR3365/packages/DAQP/